### PR TITLE
Re-show Status bar if the component unmounts before closing the drawer & close drawer on close overlay 

### DIFF
--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -64,6 +64,10 @@ export default class DrawerLayout extends React.Component {
     });
   }
 
+  componentWillUnmount() {
+    StatusBarIOS.setHidden(false, 'fade');
+  }
+
   render() {
     let { openValue } = this.state;
     let { drawerPosition, drawerWidth } = this.props;

--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -1,5 +1,5 @@
 import React from 'react-native';
-import { Animated, PanResponder, PropTypes, StyleSheet, StatusBarIOS, View, Dimensions } from 'react-native';
+import { Animated, PanResponder, PropTypes, StyleSheet, StatusBarIOS, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import autobind from 'autobind-decorator';
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
@@ -107,12 +107,19 @@ export default class DrawerLayout extends React.Component {
           {this.props.children}
         </Animated.View>
 
-        <Animated.View style={[styles.overlay, animatedOverlayStyles]} />
+        <TouchableWithoutFeedback onPress={this._onOverlayClick}>
+          <Animated.View style={[styles.overlay, animatedOverlayStyles]} />
+        </TouchableWithoutFeedback>
         <Animated.View style={[styles.drawer, dynamicDrawerStyles, animatedDrawerStyles]}>
           {this.props.renderNavigationView()}
         </Animated.View>
       </View>
     )
+  }
+
+  @autobind
+  _onOverlayClick() {
+    this.closeDrawer();
   }
 
   _emitStateChanged(newState) {

--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -1,5 +1,5 @@
 import React from 'react-native';
-import { Animated, PanResponder, PropTypes, StyleSheet, StatusBarIOS, View, Dimensions } from 'react-native';
+import { Animated, PanResponder, PropTypes, StyleSheet, StatusBarIOS, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import autobind from 'autobind-decorator';
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
@@ -107,12 +107,19 @@ export default class DrawerLayout extends React.Component {
           {this.props.children}
         </Animated.View>
 
-        <Animated.View style={[styles.overlay, animatedOverlayStyles]} />
+        <TouchableWithoutFeedback onPress={this._onOverlayPress}>
+          <Animated.View style={[styles.overlay, animatedOverlayStyles]} />
+        </TouchableWithoutFeedback>
         <Animated.View style={[styles.drawer, dynamicDrawerStyles, animatedDrawerStyles]}>
           {this.props.renderNavigationView()}
         </Animated.View>
       </View>
     )
+  }
+
+  @autobind
+  _onOverlayPress() {
+    this.closeDrawer();
   }
 
   _emitStateChanged(newState) {


### PR DESCRIPTION
I have an instance where a menu item in the drawer will pop the current route, which leaves the status bar hidden. I thought that it would be a good idea to reset the status bar in this instance to be visible again.
