### PR TITLE
Removed status bar changes from iOS Drawer Layout

### DIFF
--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -1,5 +1,5 @@
 import React from 'react-native';
-import { Animated, PanResponder, PropTypes, StyleSheet, StatusBarIOS, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
+import { Animated, PanResponder, PropTypes, StyleSheet, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import autobind from 'autobind-decorator';
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
@@ -44,12 +44,6 @@ export default class DrawerLayout extends React.Component {
     let { openValue } = this.state;
 
     openValue.addListener(({value}) => {
-      if (value >= 0.05) {
-        StatusBarIOS.setHidden(true, 'fade');
-      } else {
-        StatusBarIOS.setHidden(false, 'fade');
-      }
-
       this._lastOpenValue = value;
       this.props.onDrawerSlide && this.props.onDrawerSlide({nativeEvent: {offset: value}});
     });
@@ -62,10 +56,6 @@ export default class DrawerLayout extends React.Component {
       onPanResponderRelease: this._panResponderRelease,
       onPanResponderTerminate: (evt, gestureState) => { }
     });
-  }
-
-  componentWillUnmount() {
-    StatusBarIOS.setHidden(false, 'fade');
   }
 
   render() {


### PR DESCRIPTION
Hi there,

First of all, thanks for this great component, it was really easy to use it and did exactly what I expected, nice work! The only problem I had was the changes of the statusbar, which where not mentioned and (to my mind) unnecessary. One could easily add this behavior by adding a onDrawerSlide callback, so I don't see why it is needed, especially as the Android version doesn't behave this way.

Please be aware, that merging this PR does change the the behavior of the applications using this, so it should be mentioned somewhere. As your README doesn't contain any version log, I wasn't sure if you would like to have one there. If so, please give me feedback, I would be glad to mention this breaking change in one or two sentences. 

Have a great day!
