### PR TITLE
Add keyboard dismiss mode

### DIFF
--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -1,6 +1,7 @@
 import React from 'react-native';
 import { Animated, PanResponder, PropTypes, StyleSheet, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import autobind from 'autobind-decorator';
+import dismissKeyboard from 'dismissKeyboard';
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
 const THRESHOLD = DEVICE_WIDTH / 2;
@@ -28,7 +29,6 @@ export default class DrawerLayout extends React.Component {
     onDrawerOpen: PropTypes.func,
     onDrawerClose: PropTypes.func,
 
-    /* Not implemented */
     keyboardDismissMode: PropTypes.oneOf(['none', 'on-drag']),
   }
 
@@ -44,6 +44,16 @@ export default class DrawerLayout extends React.Component {
     let { openValue } = this.state;
 
     openValue.addListener(({value}) => {
+      if (value >= 0.05) {
+        StatusBarIOS.setHidden(true, 'fade');
+      } else {
+        StatusBarIOS.setHidden(false, 'fade');
+      }
+
+      if (this.props.keyboardDismissMode === 'on-drag') {
+        dismissKeyboard();
+      }
+
       this._lastOpenValue = value;
       this.props.onDrawerSlide && this.props.onDrawerSlide({nativeEvent: {offset: value}});
     });

--- a/DrawerLayoutExample/DrawerLayoutExample.js
+++ b/DrawerLayoutExample/DrawerLayoutExample.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var React = require('react-native');
-var { View, Text, StyleSheet, TouchableHighlight } = React;
+var { View, Text, StyleSheet, TouchableHighlight, TextInput } = React;
 var DrawerLayout = require('react-native-drawer-layout');
 
 var DrawerLayoutExample = React.createClass({
@@ -26,6 +26,7 @@ var DrawerLayoutExample = React.createClass({
         onDrawerStateChanged={(e) => this.setState({drawerStateChangedOutput: JSON.stringify(e)})}
         drawerWidth={300}
         ref={(drawer) => { return this.drawer = drawer  }}
+        keyboardDismissMode="on-drag"
         renderNavigationView={() => navigationView}>
         <View style={styles.container}>
           <Text style={styles.welcome}>Content!</Text>
@@ -34,6 +35,7 @@ var DrawerLayoutExample = React.createClass({
           <TouchableHighlight onPress={() => this.drawer.openDrawer()}>
             <Text>Open drawer</Text>
           </TouchableHighlight>
+          <TextInput style={styles.inputField} />
         </View>
       </DrawerLayout>
     );
@@ -50,6 +52,10 @@ var styles = StyleSheet.create({
     fontSize: 20,
     textAlign: 'center',
     margin: 10,
+  },
+  inputField: {
+    backgroundColor: '#F2F2F2',
+    height: 40,
   },
 });
 


### PR DESCRIPTION
Hi there,

We needed this feature in our application, so I thought it might be a nice thing to have it also here at the original component. Feel free to revert the example changes if they don't seem appropriate to you.

One may wonder where dismissKeyboard comes from, it is defined [here](https://github.com/facebook/react-native/blob/master/Libraries/Utilities/dismissKeyboard.js) and the loading in this short form works as well as writing it out (`'react-native/Libraries/Utilities/dismissKeyboard'`).

Have a nice day!
