### PR TITLE
Added support for click to close, closes #6

### DIFF
--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -103,8 +103,7 @@ export default class DrawerLayout extends React.Component {
 
         <TouchableWithoutFeedback onPress={this._onOverlayClick}>
           <Animated.View
-            style={[styles.overlay, animatedOverlayStyles]}
-            pointerEvents="none" />
+            style={[styles.overlay, animatedOverlayStyles]} />
         </TouchableWithoutFeedback>
         <Animated.View style={[styles.drawer, dynamicDrawerStyles, animatedDrawerStyles]}>
           {this.props.renderNavigationView()}
@@ -114,7 +113,8 @@ export default class DrawerLayout extends React.Component {
   }
 
   @autobind
-  _onOverlayClick() {
+  _onOverlayClick(e) {
+    e.stopPropagation();
     this.closeDrawer();
   }
 

--- a/dist/DrawerLayout.ios.js
+++ b/dist/DrawerLayout.ios.js
@@ -146,8 +146,7 @@ var DrawerLayout = (function (_React$Component) {
           _reactNative.TouchableWithoutFeedback,
           { onPress: this._onOverlayClick },
           _reactNative2.default.createElement(_reactNative.Animated.View, {
-            style: [styles.overlay, animatedOverlayStyles],
-            pointerEvents: 'none' })
+            style: [styles.overlay, animatedOverlayStyles] })
         ),
         _reactNative2.default.createElement(
           _reactNative.Animated.View,
@@ -159,7 +158,8 @@ var DrawerLayout = (function (_React$Component) {
   }, {
     key: '_onOverlayClick',
     decorators: [_autobindDecorator2.default],
-    value: function _onOverlayClick() {
+    value: function _onOverlayClick(e) {
+      e.stopPropagation();
       this.closeDrawer();
     }
   }, {


### PR DESCRIPTION
Hi there,

This PR should fix #6 :+1: 

Unfortunately I am not sure how to reproduce the bug mentioned in b9008691ea614af238296λ278674659a73645c7 by @brentvatne, would one be so kind to check if my implementation works with this usecase?

The `pointerEvents="none"` also killed the pointer events for the `TouchableWithoutFeedback` element, that was why the previous implementation didn't worked. Instead I now just stop the propagation after the `TouchableWithoutFeedback` callback gets called, so in theory we should be fine.

Have a nice day!
