### PR TITLE
Fixed #26 by requiring a relative path

### DIFF
--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -1,7 +1,7 @@
 import React from 'react-native';
 import { Animated, PanResponder, PropTypes, StyleSheet, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import autobind from 'autobind-decorator';
-import dismissKeyboard from 'dismissKeyboard';
+import dismissKeyboard from '../../react-native/Libraries/Utilities/dismissKeyboard';
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
 const THRESHOLD = DEVICE_WIDTH / 2;

--- a/dist/DrawerLayout.ios.js
+++ b/dist/DrawerLayout.ios.js
@@ -24,9 +24,9 @@ var _autobindDecorator = require('autobind-decorator');
 
 var _autobindDecorator2 = _interopRequireDefault(_autobindDecorator);
 
-var _dismissKeyboard = require('dismissKeyboard');
+var _reactNativeLibrariesUtilitiesDismissKeyboard = require('../../react-native/Libraries/Utilities/dismissKeyboard');
 
-var _dismissKeyboard2 = _interopRequireDefault(_dismissKeyboard);
+var _reactNativeLibrariesUtilitiesDismissKeyboard2 = _interopRequireDefault(_reactNativeLibrariesUtilitiesDismissKeyboard);
 
 var DEVICE_WIDTH = parseFloat(_reactNative.Dimensions.get('window').width);
 var THRESHOLD = DEVICE_WIDTH / 2;
@@ -92,7 +92,7 @@ var DrawerLayout = (function (_React$Component) {
         var value = _ref.value;
 
         if (_this.props.keyboardDismissMode === 'on-drag') {
-          (0, _dismissKeyboard2.default)();
+          (0, _reactNativeLibrariesUtilitiesDismissKeyboard2.default)();
         }
 
         _this._lastOpenValue = value;


### PR DESCRIPTION
The react native packager changed its behavior, so that simlpy requiring it won't work

Instead we use the relative path now, we should occasionally check if the global require will work again, as this may break on restructuring
Additionally had to add autobind-decorators back, as we still use them even after compiling, just in another syntax
