### PR TITLE
Fixed import bug with dismissKeyboard

### DIFF
--- a/DrawerLayout.ios.js
+++ b/DrawerLayout.ios.js
@@ -1,7 +1,7 @@
 import React from 'react-native';
 import { Animated, PanResponder, PropTypes, StyleSheet, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import autobind from 'autobind-decorator';
-import dismissKeyboard from '../../react-native/Libraries/Utilities/dismissKeyboard';
+import dismissKeyboard from 'react-native-dismiss-keyboard';
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
 const THRESHOLD = DEVICE_WIDTH / 2;

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "autobind-decorator": "^1.3.2"
+    "autobind-decorator": "^1.3.2",
+    "react-native-dismiss-keyboard": "0.0.2"
   },
   "devDependencies": {
     "babel": "^5.8.34",


### PR DESCRIPTION
Hi there,

I just created a small npm package for the keyboard dismissal in react-native and included it in the project, this should fix the bug #37 and maybe also #32 

I really hope this is the last time I have to see dismissKeyboard :+1: 

Have a nice day!
