### PR TITLE
Don't render the overlay if drawer is not open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-drawer-layout",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A platform-agnostic drawer layout. Pure JavaScript implementation on iOS and native implementation on Android. Why? Because the drawer layout is a useful component regardless of the platform! And if you can use it without changing any code, that's perfect.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/DrawerLayout.ios.js
+++ b/src/DrawerLayout.ios.js
@@ -89,6 +89,7 @@ export default class DrawerLayout extends React.Component {
       extrapolate: 'clamp',
     });
     const animatedDrawerStyles = { transform: [{ translateX: drawerTranslateX }] };
+    const drawerShown = openValue > 0;
 
     /* Overlay styles */
     const overlayOpacity = openValue.interpolate({
@@ -104,10 +105,12 @@ export default class DrawerLayout extends React.Component {
           {this.props.children}
         </Animated.View>
 
-        <TouchableWithoutFeedback onPress={this._onOverlayClick}>
-          <Animated.View
-            style={[styles.overlay, animatedOverlayStyles]} />
-        </TouchableWithoutFeedback>
+        {drawerShown &&
+          <TouchableWithoutFeedback onPress={this._onOverlayClick}>
+            <Animated.View
+              style={[styles.overlay, animatedOverlayStyles]} />
+          </TouchableWithoutFeedback>
+        }
         <Animated.View style={[styles.drawer, dynamicDrawerStyles, animatedDrawerStyles]}>
           {this.props.renderNavigationView()}
         </Animated.View>


### PR DESCRIPTION
Hi there,

I fixed #15 by simply not rendering the overlay as long as the drawer is not shown at all. Afterwards not beeing able to click is the intended behaviour. 
