### PR TITLE
Improved animation performance under heavy load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-drawer-layout",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "A platform-agnostic drawer layout. Pure JavaScript implementation on iOS and native implementation on Android. Why? Because the drawer layout is a useful component regardless of the platform! And if you can use it without changing any code, that's perfect.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/DrawerLayout.ios.js
+++ b/src/DrawerLayout.ios.js
@@ -1,7 +1,17 @@
 import React from 'react-native';
-import { Animated, PanResponder, PropTypes, StyleSheet, View, Dimensions, TouchableWithoutFeedback } from 'react-native';
 import autobind from 'autobind-decorator';
 import dismissKeyboard from 'react-native-dismiss-keyboard';
+
+const {
+  Animated,
+  Dimensions,
+  InteractionManager,
+  PanResponder,
+  PropTypes,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View,
+} = React;
 
 const DEVICE_WIDTH = parseFloat(Dimensions.get('window').width);
 const THRESHOLD = DEVICE_WIDTH / 2;
@@ -38,6 +48,8 @@ export default class DrawerLayout extends React.Component {
   constructor(props, context) {
     super(props, context);
 
+    this.interactionHandle = null;
+
     this.state = {
       openValue: new Animated.Value(0),
       drawerShown: false,
@@ -55,6 +67,14 @@ export default class DrawerLayout extends React.Component {
 
       if (this.props.keyboardDismissMode === 'on-drag') {
         dismissKeyboard();
+      }
+
+      if (value === 0 || value === 1) {
+        if (this.interactionHandle) {
+          InteractionManager.clearInteractionHandle(this.interactionHandle);
+        }
+      } else {
+        this.interactionHandle = InteractionManager.createInteractionHandle();
       }
 
       this._lastOpenValue = value;


### PR DESCRIPTION
Hi there,

I did this by adding InteractionManager.createInteractionHandle() as proposed in #2. This allows the user to defer calculation on the JS thread until the animation is done and, therefore, have a more reactive application. Hopefully, we can now close our almost last issue ;) 

If you want to give it a try, [here is a demo](https://github.com/DanielMSchmidt/DrawerLayoutHeavyLoadExample), it performs way worse with 0.3.5 than with 0.4.0.

Have a nice day!
