### PR TITLE
Add basic test structure

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,7 @@
 {
-  "extends": "react-native/packager/react-packager/.babelrc",
+  "presets": [
+    "react-native"
+  ],
   "plugins": [
     "transform-decorators-legacy"
   ],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run-script clear && npm run-script babel",
     "clear": "rm -rf dist/ && mkdir dist/",
     "prepublish": "npm run build",
-    "test": "xo"
+    "test": "xo && mocha test/"
   },
   "files": [
     "dist/"
@@ -96,13 +96,20 @@
     "babel-cli": "^6.0.0",
     "babel-eslint": "^5.0.0-beta6",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-react-native": "^1.5.2",
+    "chai": "^3.5.0",
+    "chai-enzyme": "^0.4.1",
+    "enzyme": "^2.1.0",
     "eslint": "^1.10.3",
     "eslint-config-xo": "^0.9.1",
     "eslint-plugin-babel": "^3.0.0",
     "eslint-plugin-no-empty-blocks": "0.0.2",
     "eslint-plugin-no-use-extend-native": "^0.3.3",
     "eslint-plugin-react": "^3.13.1",
-    "react-native": "^0.17.0",
+    "mocha": "^2.4.5",
+    "react-dom": "^0.14.7",
+    "react-native": "^0.21.0",
+    "react-native-mock": "0.0.6",
     "xo": "^0.12.1"
   }
 }

--- a/test/DrawerLayout.js
+++ b/test/DrawerLayout.js
@@ -1,0 +1,26 @@
+import React from 'react-native';
+
+import DrawerLayout from '../src/DrawerLayout.ios';
+import { describe } from 'mocha';
+import { expect } from 'chai';
+import { it } from 'mocha';
+import { shallow } from 'enzyme';
+
+const {
+  Text,
+} = React;
+
+const DEFAULT_PROPS = {
+  drawerPosition: DrawerLayout.positions.Left,
+  drawerWidth: 300,
+  renderNavigationView: () => (
+    <Text>Empty</Text>
+  ),
+};
+
+describe('<DrawerLayout />', () => {
+  it('should render', () => {
+    const wrapper = shallow(<DrawerLayout {...DEFAULT_PROPS} />);
+    expect(wrapper.length).to.equal(1);
+  });
+});

--- a/test/chai.js
+++ b/test/chai.js
@@ -1,0 +1,4 @@
+import chai from 'chai';
+import chaiEnzyme from 'chai-enzyme';
+
+chai.use(chaiEnzyme());

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--require react-native-mock/mock.js
+--require test/chai.js
+--compilers js:babel-core/register
+--recursive


### PR DESCRIPTION
This adds a basic test structure using Enzym with Mocha + Chai.

Due a bug in `react-native-mock` this PR won't work till lelandrichardson/react-native-mock#24 is merged.

This closes #24, but you need to add a few more tests :)
