### PR TITLE
Added support for drawerLockMode prop

### DIFF
--- a/src/DrawerLayout.ios.js
+++ b/src/DrawerLayout.ios.js
@@ -35,6 +35,7 @@ export default class DrawerLayout extends React.Component {
 
   static propTypes = {
     children: React.PropTypes.node,
+    drawerLockMode: PropTypes.oneOf(['unlocked', 'locked-closed', 'locked-open']),
     drawerPosition: PropTypes.oneOf(['left', 'right']).isRequired,
     drawerWidth: PropTypes.number.isRequired,
     keyboardDismissMode: PropTypes.oneOf(['none', 'on-drag']),
@@ -146,7 +147,9 @@ export default class DrawerLayout extends React.Component {
   @autobind
   _onOverlayClick(e) {
     e.stopPropagation();
-    this.closeDrawer();
+    if (!this._isLockedClosed() && !this._isLockedOpen()) {
+      this.closeDrawer();
+    }
   }
 
   _emitStateChanged(newState) {
@@ -194,6 +197,10 @@ export default class DrawerLayout extends React.Component {
   @autobind
   _shouldSetPanResponder(e, { moveX, dx, dy }) {
     const { drawerPosition } = this.props;
+
+    if (this._isLockedClosed() || this._isLockedOpen()) {
+      return false;
+    }
 
     if (drawerPosition === 'left') {
       const overlayArea = DEVICE_WIDTH - (DEVICE_WIDTH - this.props.drawerWidth);
@@ -283,6 +290,14 @@ export default class DrawerLayout extends React.Component {
         this.closeDrawer();
       }
     }
+  }
+
+  _isLockedClosed() {
+    return this.props.drawerLockMode === 'locked-closed' && !this.state.drawerShown;
+  }
+
+  _isLockedOpen() {
+    return this.props.drawerLockMode === 'locked-open' && this.state.drawerShown;
   }
 
   _getOpenValueForX(x) {


### PR DESCRIPTION
Fixes #52 

This PR adds support for the drawerLockMode prop with the following behavior:
- `drawerLockMode='locked-open'`:
  - when drawer is open, user can not close it by drag or tap on overlay. Drawer can still be closed programmatically.
  - when drawer is closed, user can open the drawer (unspecified case)
- `drawerLockMode='locked-closed'`:
  - when drawer is closed, user can not open it. Drawer can still be open programmatically.
  - when drawer is open, user can close the drawer (unspecified case)

This behavior seems to match the [DrawerLayoutAndroid documentation](https://facebook.github.io/react-native/docs/drawerlayoutandroid.html).
However, my implementation slightly differs from what I tested on my Android device. You could expect that `locked-open` only locks opening, and `locked-closed` only locks closing (as implemented in this PR). But, in the unspecified cases, any `locked-*` value actually locks the drawer for both opening and closing.
