### PR TITLE
Use JS/iOS implementation for all non-Android platforms

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
-const React = require('react-native');
-const { Platform, DrawerLayoutAndroid } = React;
+import {
+  Platform,
+  DrawerLayoutAndroid,
+} from 'react-native';
 
 if (Platform.OS === 'android') {
   module.exports = DrawerLayoutAndroid;
-} else if (Platform.OS === 'ios') {
+} else {
   module.exports = require('./DrawerLayout.ios').default;
 }


### PR DESCRIPTION
- Default to JS implementation of drawer for all non-Android platforms, not just iOS
- Modernize RN imports